### PR TITLE
Update enable button translation for Japanese

### DIFF
--- a/app/src/main/java/com/brouken/wear/payenabler/EnablerAccessibilityService.java
+++ b/app/src/main/java/com/brouken/wear/payenabler/EnablerAccessibilityService.java
@@ -50,7 +50,7 @@ public class EnablerAccessibilityService extends AccessibilityService {
                         /* hi */ || text.equals("सक्षम करें") || text.equals("चालू कर")
                         /* in */ || text.equals("Aktifkan")
                         /* it */ || text.equals("Attiva")
-                        /* ja */ || text.equals("有効にする")
+                        /* ja */ || text.equals("有効化")
                         /* ko */ || text.equals("사용") || text.equals("사용 설정")
                         /* nb */ || text.equals("Slå på")
                         /* nl */ || text.equals("Inschakelen")

--- a/app/src/main/java/com/brouken/wear/payenabler/EnablerAccessibilityService.java
+++ b/app/src/main/java/com/brouken/wear/payenabler/EnablerAccessibilityService.java
@@ -50,7 +50,7 @@ public class EnablerAccessibilityService extends AccessibilityService {
                         /* hi */ || text.equals("सक्षम करें") || text.equals("चालू कर")
                         /* in */ || text.equals("Aktifkan")
                         /* it */ || text.equals("Attiva")
-                        /* ja */ || text.equals("有効化")
+                        /* ja */ || text.equals("有効にする") || text.equals("有効化")
                         /* ko */ || text.equals("사용") || text.equals("사용 설정")
                         /* nb */ || text.equals("Slå på")
                         /* nl */ || text.equals("Inschakelen")


### PR DESCRIPTION
On Wear OS 2.7, the Japanese text on the "Enable" button is 有効化 ( ゆうこうか ), not 有効にする.